### PR TITLE
Doctests to nosetests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ script:
   - "wget http://d3kbcqa49mib13.cloudfront.net/spark-1.0.0-bin-hadoop2.tgz"
   - "tar -xvf spark-1.0.0-bin-hadoop2.tgz"
   # Run the tests
-  - "SPARK_HOME=./spark-1.0.0-bin-hadoop2/ ./run-tests"
+  - "export SPARK_HOME=./spark-1.0.0-bin-hadoop2/"
+  - "nosetests --logging-level=INFO --detailed-errors"

--- a/pandaspark/pcontext.py
+++ b/pandaspark/pcontext.py
@@ -61,14 +61,7 @@ class PSparkContext():
 
     def DataFrame(self, elements, *args, **kwargs):
         """
-        Wraps the pandas.DataFrame operation
-        >>> input = [("tea", "happy"), ("water", "sad"), ("coffee", "happiest")]
-        >>> prdd = psc.DataFrame(input, columns=['magic', 'thing'])
-        >>> elements = prdd.collect()
-        >>> len(elements)
-        3
-        >>> sorted(elements['magic'])
-        ['coffee', 'tea', 'water']
+        Wraps the pandas.DataFrame operation.
         """
         return PRDD.fromRDD(self.sc.parallelize(elements).map(
             lambda element: pandas.DataFrame(data = [element], *args, **kwargs)))

--- a/pandaspark/prdd.py
+++ b/pandaspark/prdd.py
@@ -45,14 +45,7 @@ class PRDD:
     def applymap(self, f, **kwargs):
         """
         Return a new PRDD by applying a function to each element of each
-        Panda DataFrame
-
-        >>> input = [("tea", "happy"), ("water", "sad"), ("coffee", "happiest")]
-        >>> prdd = psc.DataFrame(input, columns=['magic', 'thing'])
-        >>> addpandasfunc = (lambda x: "panda" + x)
-        >>> result = prdd.applymap(addpandasfunc).collect()
-        >>> str(result.sort(['magic'])).replace(' ','').replace('\\n','')
-        'magicthing0pandacoffeepandahappiest0pandateapandahappy0pandawaterpandasad...'
+        Panda DataFrame.
         """
         return self.fromRDD(self._rdd.map(lambda data: data.applymap(f), **kwargs))
 
@@ -60,10 +53,7 @@ class PRDD:
         """
         Returns a new PRDD of elements from that key
 
-        >>> input = [("tea", "happy"), ("water", "sad"), ("coffee", "happiest")]
-        >>> prdd = psc.DataFrame(input, columns=['magic', 'thing'])
-        >>> str(prdd['thing'].collect()).replace(' ','').replace('\\n','')
-        '0happy0sad0happiestName:thing,dtype:object'
+
         """
         return self.fromRDD(self._rdd.map(lambda x: x[key]))
 
@@ -71,11 +61,6 @@ class PRDD:
         """
         Collect the elements in an PRDD and concatenate the partition
 
-        >>> input = [("tea", "happy"), ("water", "sad"), ("coffee", "happiest")]
-        >>> prdd = psc.DataFrame(input, columns=['magic', 'thing'])
-        >>> elements = prdd.collect()
-        >>> str(elements.sort(['magic']))
-        '    magic     thing\\n0  coffee  happiest\\n0     tea     happy\\n0   water       sad...'
         """
         def appendFrames(frame_a, frame_b):
             return frame_a.append(frame_b)
@@ -87,11 +72,6 @@ class PRDD:
         Parameters
         ----------
         columns : list of str, contains all comuns for which to compute stats on
-        >>> input = [("magic", 10), ("ninja", 20), ("coffee", 30)]
-        >>> prdd = psc.DataFrame(input, columns=['a', 'b'])
-        >>> stats = prdd.stats(columns=['b'])
-        >>> str(stats)
-        '(field: b,  counters: (count: 3, mean: 20.0, stdev: 8.16496580928, max: 30, min: 10))'
         """
         def reduceFunc(sc1, sc2):
             return sc1.merge_pstats(sc2)

--- a/pandaspark/pstatcounter.py
+++ b/pandaspark/pstatcounter.py
@@ -48,13 +48,7 @@ class PStatCounter(object):
 
     def merge(self, frame):
         """
-        Add another DataFrame to the PStatCounter
-        >>> import pandas
-        >>> from pandaspark.pstatcounter import PStatCounter
-        >>> input = [("magic", 10), ("ninja", 20), ("coffee", 30)]
-        >>> df = pandas.DataFrame(data = input, columns = ['a', 'b'])
-        >>> PStatCounter([df], columns=['b'])
-        (field: b,  counters: (count: 3, mean: 20.0, stdev: 8.16496580928, max: 30, min: 10))
+        Add another DataFrame to the PStatCounter.
         """
         for column, values in frame.iteritems():
             # Temporary hack, fix later

--- a/pandaspark/test/pcontext_tests.py
+++ b/pandaspark/test/pcontext_tests.py
@@ -1,5 +1,6 @@
-#!/usr/bin/env bash
-
+"""
+Test methods in pcontext
+"""
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -17,32 +18,13 @@
 # limitations under the License.
 #
 
-FAILED=0
+from pandaspark.test.pandasparktestcase import PandaSparkTestCase
 
-rm -f unit-tests.log
+class PContext_Tests(PandaSparkTestCase):
 
-function run_test() {
-    python $1 2>&1 | tee -a  unit-tests.log
-    FAILED=$((PIPESTATUS[0]||$FAILED))
-
-    # Fail and exit on the first test failure.
-    if [[ $FAILED != 0 ]]; then
-        cat unit-tests.log | grep -v "^[0-9][0-9]*" # filter all lines starting with a number.
-        echo -en "\033[31m"  # Red
-        echo "Had test failures; see logs."
-        echo -en "\033[0m"  # No color
-        exit -1
-    fi
-
-}
-
-run_test "./pandaspark/pcontext.py"
-run_test "./pandaspark/pstatcounter.py"
-run_test "./pandaspark/prdd.py"
-run_test "./pandaspark/test/dataloadtests.py"
-
-if [[ $FAILED == 0 ]]; then
-    echo -en "\033[32m"  # Green
-    echo "Tests passed."
-    echo -en "\033[0m"  # No color
-fi
+    def test_dataframe_construction(self):
+        input = [("tea", "happy"), ("water", "sad"), ("coffee", "happiest")]
+        prdd = self.psc.DataFrame(input, columns=['magic', 'thing'])
+        elements = prdd.collect()
+        assert len(elements) == 3
+        assert sorted(elements['magic']) == ['coffee', 'tea', 'water']

--- a/pandaspark/test/prdd_tests.py
+++ b/pandaspark/test/prdd_tests.py
@@ -1,0 +1,74 @@
+"""
+Test methods in prdd
+"""
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pandaspark.test.pandasparktestcase import PandaSparkTestCase
+
+import pandas as pd
+import numpy.testing as np_tests
+
+class PContext_Tests(PandaSparkTestCase):
+
+    def test_apply_map(self):
+        input = [("tea", "happy"), ("water", "sad"), ("coffee", "happiest")]
+        prdd = self.psc.DataFrame(input, columns=['magic', 'thing'])
+        addpandasfunc = (lambda x: "panda" + x)
+        result = prdd.applymap(addpandasfunc).collect()
+
+        expected_thing_result = ["pandahappy", "pandasad", "pandahappiest"]
+        expected_magic_result = ["pandatea", "pandawater", "pandacoffee"]
+        actual_thing_result = result["thing"].values.tolist()
+        actual_magic_result = result["magic"].values.tolist()
+
+        assert isinstance(result, type(pd.DataFrame()))
+        assert expected_magic_result == actual_magic_result
+        assert expected_thing_result == actual_thing_result
+
+    def test_get_item(self):
+        input = [("tea", "happy"), ("water", "sad"), ("coffee", "happiest")]
+        prdd = self.psc.DataFrame(input, columns=['magic', 'thing'])
+        actual_col = prdd['thing'].collect()
+        actual_thing_result = actual_col.values.tolist()
+        expected_thing_result = ["happy", "sad", "happiest"]
+        assert expected_thing_result == actual_thing_result
+
+    def test_collect(self):
+        input = [("tea", "happy"), ("water", "sad"), ("coffee", "happiest")]
+        prdd = self.psc.DataFrame(input, columns=['magic', 'thing'])
+        collected_result = prdd.collect()
+
+        expected_thing_result = ["happy", "sad", "happiest"]
+        expected_magic_result = ["tea", "water", "coffee"]
+        actual_thing_result = collected_result["thing"].values.tolist()
+        actual_magic_result = collected_result["magic"].values.tolist()
+
+        assert isinstance(collected_result, type(pd.DataFrame()))
+        assert expected_magic_result == actual_magic_result
+        assert expected_thing_result == actual_thing_result
+
+    def test_stats(self):
+        input = [("magic", 10), ("ninja", 20), ("coffee", 30)]
+        prdd = self.psc.DataFrame(input, columns=['a', 'b'])
+        stats = prdd.stats(columns=['b'])
+        b_col_stat_counter = stats._counters['b']
+        np_tests.assert_almost_equal(b_col_stat_counter.count(), 3)
+        np_tests.assert_almost_equal(b_col_stat_counter.mean(), 20.0)
+        np_tests.assert_almost_equal(b_col_stat_counter.stdev(), 8.16496580928)
+        np_tests.assert_almost_equal(b_col_stat_counter.max(), 30)
+        np_tests.assert_almost_equal(b_col_stat_counter.min(), 10)


### PR DESCRIPTION
Move almost all doc tests to unit tests that are the run through nosetest instead of a custom script. When run in travis, we wiil use the --logging-level=INFO and --detailed-errors.
