### PR TITLE
Upgrade to spark 1.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - "pip install ."
 script:
   # Download spark 1.4.0
-  - "wget http://download.nextag.com/apache/spark/spark-1.4.0/spark-1.4.0-hadoop2.4.tgz "
+  - "wget http://download.nextag.com/apache/spark/spark-1.4.0/spark-1.4.0-bin-hadoop2.4.tgz"
   - "tar -xvf spark-1.4.0-bin-hadoop2.4.tgz"
   # Run the tests
   - "export SPARK_HOME=./spark-1.4.0-bin-hadoop2.4/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ install:
   # install our own package into the environment
   - "pip install ."
 script:
-  # Download spark 1.3.1
-  - "wget http://download.nextag.com/apache/spark/spark-1.3.1/spark-1.3.1-bin-hadoop2.4.tgz"
-  - "tar -xvf spark-1.3.1-bin-hadoop2.4.tgz"
+  # Download spark 1.4.0
+  - "wget http://download.nextag.com/apache/spark/spark-1.4.0/spark-1.4.0-hadoop2.4.tgz "
+  - "tar -xvf spark-1.4.0-bin-hadoop2.4.tgz"
   # Run the tests
-  - "export SPARK_HOME=./spark-1.3.1-bin-hadoop2.4/"
+  - "export SPARK_HOME=./spark-1.4.0-bin-hadoop2.4/"
   - "./run-tests"
   - "pep8 --ignore=E402 sparklingpandas/"
   

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ An early version of Sparkling Pandas was discussed in [Sparkling Pandas - using 
 Requirements
 =========
 
-The primary requirement of SparklingPandas is that you have a recent (v1.3
+The primary requirement of SparklingPandas is that you have a recent (v1.4
 currently) version of Spark installed - <http://spark.apache.org> and Python
 2.7.
 

--- a/sparklingpandas/groupby.py
+++ b/sparklingpandas/groupby.py
@@ -251,7 +251,7 @@ class GroupBy:
         if not columns:
             columns = self._columns
         from pyspark.sql import functions as F
-        aggs = map(lambda column: agg(column).as(column), self._columns)
+        aggs = map(lambda column: agg(column).alias(column), self._columns)
         aggRdd = self._grouped_spark_sql.agg(*aggs)
         df = Dataframe.fromSchemaRDD(aggRdd)
         df._index_names = [self._by]

--- a/sparklingpandas/groupby.py
+++ b/sparklingpandas/groupby.py
@@ -251,16 +251,9 @@ class GroupBy:
         if not columns:
             columns = self._columns
         from pyspark.sql import functions as F
-        aggs = list([F.first(self._by)] +
-                    map(lambda column: agg(column), self._columns))
+        aggs = map(lambda column: agg(column).as(column), self._columns)
         aggRdd = self._grouped_spark_sql.agg(*aggs)
-        renamedRdd = aggRdd
-        for column in self._columns:
-            fromName = aggName + "(" + column + ")"
-            renamedRdd = renamedRdd.withColumnRenamed(fromName, column)
-        renamedRdd = renamedRdd.withColumnRenamed("FIRST(" + self._by + ")",
-                                                  self._by)
-        df = Dataframe.fromSchemaRDD(renamedRdd)
+        df = Dataframe.fromSchemaRDD(aggRdd)
         df._index_names = [self._by]
         return df
 


### PR DESCRIPTION
Upgrade to Spark 1.4.0, Spark SQL now keeps the groupBy column info among other things.