### PR TITLE
Fix csv reading capability by correcting case of method.

### DIFF
--- a/sparklingpandas/pcontext.py
+++ b/sparklingpandas/pcontext.py
@@ -105,10 +105,10 @@ class PSparkContext():
 
         # Do the actual load
         if use_whole_file:
-            return self.from_pandas_RDD(
+            return self.from_pandas_rdd(
                 self.sc.wholeTextFiles(name).mapPartitionsWithIndex(csv_file))
         else:
-            return self.from_pandas_RDD(
+            return self.from_pandas_rdd(
                 self.sc.textFile(name).mapPartitionsWithIndex(csv_rows))
 
     def parquetFile(self, *paths):

--- a/sparklingpandas/test/pcontexttests.py
+++ b/sparklingpandas/test/pcontexttests.py
@@ -18,6 +18,7 @@ Test methods in pcontext
 # limitations under the License.
 #
 import json
+import csv
 import os
 import tempfile
 
@@ -52,3 +53,21 @@ class PContextTests(SparklingPandasTestCase):
         assert len(elements) == 3
         expected = sorted([u'coffee', u'tea', u'water'])
         assert sorted(elements['magic']) == expected
+
+    def test_read_csv(self):
+        input = [["happy", 3],
+                 ["grumpy", 4],
+                 ["dopey", 5]]
+
+        temp_file = tempfile.NamedTemporaryFile(delete=False)
+        temp_file.close()
+
+        with open(temp_file.name, 'wb') as f:
+            writer = csv.writer(f)
+            writer.write_rows(input)
+
+        df = self.psc.read_csv(temp_file.name)
+        elements = df.collect()
+        os.unlink(temp_file.name)
+
+        assert len(elements) == 3


### PR DESCRIPTION
Adds a test that reproduces a csv reading bug I found. Fixes it pretty easily. This bug makes me think we should be using pylint as part of out test system. Will address that soon.