### PR TITLE
Rework testing cmd.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ script:
   - ./sbt/sbt compile package
   # Run the tests
   - "export SPARK_HOME=./spark-1.4.0-bin-hadoop2.4/"
-  - "./run-tests"
+  - "nosetests --logging-level=INFO --detailed-errors --verbosity=2 --with-coverage --cover-html-dir=./htmlcov --cover-package=sparklingpandas"
   - "pep8 --ignore=E402 sparklingpandas/"
   

--- a/run-tests
+++ b/run-tests
@@ -1,7 +1,0 @@
-#!/bin/bash
-if [ -z "$SPARK_HOME" ]; then
-   echo "$(tput setaf 1)Error: SPARK_HOME is not set, can not run tests.$(tput sgr0)"
-   exit -1
-fi
-JARS=`ls ./target/scala-2.10/*.jar`
-PYSPARK_SUBMIT_ARGS="--jars $JARS --driver-class-path $JARS pyspark-shell" PYTHON_PATH=./ nosetests --logging-level=INFO --detailed-errors --verbosity=2 --with-coverage --cover-html-dir=./htmlcov --cover-package=sparklingpandas

--- a/sparklingpandas/test/__init__.py
+++ b/sparklingpandas/test/__init__.py
@@ -3,12 +3,39 @@ Tests for the PandaSpark module, you probably don't want to import this
 directly.
 """
 import subprocess as sub
+import os
 
-try:
-    sub.check_output("source ./sparklingpandas/test/resources/setup-test-env"
-                     + ".sh", shell=True,
-                        stderr=sub.STDOUT)
-except sub.CalledProcessError, err:
+
+def run_cmd(cmd):
+    """Execute the command and return the output if successful. If
+    unsuccessful, print the failed command and its output.
+    """
+    try:
+        out = sub.check_output(cmd, shell=True, stderr=sub.STDOUT)
+        return out
+    except sub.CalledProcessError, err:
         print "The failed test setup command was [%s]." % err.cmd
         print "The output of the command was [%s]" % err.output
         raise
+
+
+def jars_cmd(project_root):
+    return
+
+CHECK_SPARK_HOME = """
+if [ -z "$SPARK_HOME" ]; then
+   echo "Error: SPARK_HOME is not set, can't run tests."
+   exit -1
+fi
+"""
+os.system(CHECK_SPARK_HOME)
+
+# Dynamically load project root dir and sparkling pandas jars.
+project_root = os.getcwd()
+jars = run_cmd("ls %s/target/scala-2.10/*.jar" % project_root)
+
+# Set environment variables.
+os.environ["PYTHON_PATH"] = project_root
+args = "--jars %s --driver-class-path %s pyspark-shell" % (jars, jars)
+os.environ["PYSPARK_SUBMIT_ARGS"] = args
+os.environ["JARS"] = jars

--- a/sparklingpandas/test/__init__.py
+++ b/sparklingpandas/test/__init__.py
@@ -2,3 +2,13 @@
 Tests for the PandaSpark module, you probably don't want to import this
 directly.
 """
+import subprocess as sub
+
+try:
+    sub.check_output("source ./sparklingpandas/test/resources/setup-test-env"
+                     + ".sh", shell=True,
+                        stderr=sub.STDOUT)
+except sub.CalledProcessError, err:
+        print "The failed test setup command was [%s]." % err.cmd
+        print "The output of the command was [%s]" % err.output
+        raise

--- a/sparklingpandas/test/dataframe_tests.py
+++ b/sparklingpandas/test/dataframe_tests.py
@@ -30,7 +30,7 @@ from pandas.util.testing import (assert_almost_equal,
                                  assert_index_equal)
 
 
-class PContextTests(SparklingPandasTestCase):
+class DataframeTests(SparklingPandasTestCase):
 
     def test_apply_map(self):
         input = [("tea", "happy"), ("water", "sad"), ("coffee", "happiest")]

--- a/sparklingpandas/test/resources/setup-test-env.sh
+++ b/sparklingpandas/test/resources/setup-test-env.sh
@@ -4,6 +4,9 @@ if [ -z "$SPARK_HOME" ]; then
    exit -1
 fi
 
-JARS=`ls ./target/scala-2.10/*.jar`
+CURRENT_DIR=`pwd`
+PROJECT_ROOT=`cd $x/../../../.. && pwd`
+
+JARS=`ls $PROJECT_ROOT/target/scala-2.10/*.jar`
 PYSPARK_SUBMIT_ARGS="--jars $JARS --driver-class-path $JARS pyspark-shell"
-PYTHON_PATH=./../../../..
+PYTHON_PATH=$PROJECT_ROOT:$PYHTON_PATH

--- a/sparklingpandas/test/resources/setup-test-env.sh
+++ b/sparklingpandas/test/resources/setup-test-env.sh
@@ -6,4 +6,4 @@ fi
 
 JARS=`ls ./target/scala-2.10/*.jar`
 PYSPARK_SUBMIT_ARGS="--jars $JARS --driver-class-path $JARS pyspark-shell"
-PYTHON_PATH=./
+PYTHON_PATH=./../../../..

--- a/sparklingpandas/test/resources/setup-test-env.sh
+++ b/sparklingpandas/test/resources/setup-test-env.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [ -z "$SPARK_HOME" ]; then
+   echo "$(tput setaf 1)Error: SPARK_HOME is not set, can not run tests.$(tput sgr0)"
+   exit -1
+fi
+
+JARS=`ls ./target/scala-2.10/*.jar`
+PYSPARK_SUBMIT_ARGS="--jars $JARS --driver-class-path $JARS pyspark-shell"
+PYTHON_PATH=./

--- a/sparklingpandas/test/sparklingpandastestcase.py
+++ b/sparklingpandas/test/sparklingpandastestcase.py
@@ -44,6 +44,7 @@ class SparklingPandasTestCase(unittest2.TestCase):
         conf.set("spark.cores.max", "4")
         conf.set("spark.master", "local[4]")
         conf.set("spark.app-name", class_name)
+        conf.set("spark.driver.allowMultipleContexts", "true")
         self.psc = PSparkContext.simple(conf=conf)
         # Add a common basic input and basicpframe we can reuse in testing
         self.basicinput = [


### PR DESCRIPTION
This allows us to run `nosetests` directly from the command line. It shifts the responsibility of setting up the env to the __init__ for the testing module. __init__ gets called exactly once when the module is first used. There are two problems in this current version:
1) test_apply_map fails with:

    ...
    File "/Users/juliet/src/sparklingpandas/sparklingpandas/custom_functions.py", line 29, in registerSQLExtensions
    sc._jvm.com.sparklingpandas.functions.registerUdfs(scala_SQLContext)
    File "/Users/juliet/bin/spark-1.4.1-bin-hadoop2.6/python/lib/py4j-0.8.2.1-src.zip/py4j/java_gateway.py", line 726, in __getattr__
    raise Py4JError('Trying to call a package.')
    Py4JError: Trying to call a package.

2) That failure cascades into other test failures because of a lack of the proper cleanup of the spark contexts. The class defining those tests does extend SparklingPandasTestCase so it should have tearDown called after the test is run. Not sure what is up with that.